### PR TITLE
Test solution to fix building sqlite3

### DIFF
--- a/nodejs-project/package-lock.json
+++ b/nodejs-project/package-lock.json
@@ -20,8 +20,8 @@
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "resolved": "git+ssh://git@github.com/JaneaSystems/mapbox-node-pre-gyp.git#cd5f1b4c0ca0b2b14a7d650441c3a9bff4150a6e",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",

--- a/nodejs-project/package.json
+++ b/nodejs-project/package.json
@@ -10,5 +10,10 @@
   "license": "MIT",
   "dependencies": {
     "sqlite3": "^5.1.6"
+  },
+  "overrides": {
+    "sqlite3": {
+      "@mapbox/node-pre-gyp": "github:JaneaSystems/mapbox-node-pre-gyp#add-support-for-nodejs-mobile"
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@angular/compiler-cli": "^16.0.0",
         "@angular/language-service": "^16.0.0",
         "@ionic/angular-toolkit": "^9.0.0",
-        "@red-mobile/nodejs-mobile-cordova": "github:okhiroyuki/nodejs-mobile-cordova#main",
+        "@red-mobile/nodejs-mobile-cordova": "github:JaneaSystems/redmobile-nodejs-mobile-cordova#fix-mobile-gyp-resolution",
         "@types/jasmine": "~4.3.0",
         "@types/node": "^12.11.1",
         "@typescript-eslint/eslint-plugin": "5.3.0",
@@ -3799,7 +3799,7 @@
     },
     "node_modules/@red-mobile/nodejs-mobile-cordova": {
       "version": "3.1.0",
-      "resolved": "git+ssh://git@github.com/okhiroyuki/nodejs-mobile-cordova.git#d10ad0e380ad7d41c93f9d8431af2bca6651fd05",
+      "resolved": "git+ssh://git@github.com/JaneaSystems/redmobile-nodejs-mobile-cordova.git#6eb1ba5326418744b5eec4db16655804cae43acd",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19111,9 +19111,9 @@
       "optional": true
     },
     "@red-mobile/nodejs-mobile-cordova": {
-      "version": "git+ssh://git@github.com/okhiroyuki/nodejs-mobile-cordova.git#d10ad0e380ad7d41c93f9d8431af2bca6651fd05",
+      "version": "git+ssh://git@github.com/JaneaSystems/redmobile-nodejs-mobile-cordova.git#6eb1ba5326418744b5eec4db16655804cae43acd",
       "dev": true,
-      "from": "@red-mobile/nodejs-mobile-cordova@github:okhiroyuki/nodejs-mobile-cordova#main",
+      "from": "@red-mobile/nodejs-mobile-cordova@github:JaneaSystems/redmobile-nodejs-mobile-cordova#fix-mobile-gyp-resolution",
       "requires": {
         "node-gyp-build-mobile": "4.6.0-3",
         "nodejs-mobile-gyp": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@angular/compiler-cli": "^16.0.0",
     "@angular/language-service": "^16.0.0",
     "@ionic/angular-toolkit": "^9.0.0",
-    "@red-mobile/nodejs-mobile-cordova": "github:okhiroyuki/nodejs-mobile-cordova#main",
+    "@red-mobile/nodejs-mobile-cordova": "github:JaneaSystems/redmobile-nodejs-mobile-cordova#fix-mobile-gyp-resolution",
     "@types/jasmine": "~4.3.0",
     "@types/node": "^12.11.1",
     "@typescript-eslint/eslint-plugin": "5.3.0",


### PR DESCRIPTION
This applies the fixes required to build sqlite3 as part of a nodejs-mobile project in Cordova. It serves as a way to validate a solution before opening upstream PRs to the fixed components.

It uses a fork of https://github.com/okhiroyuki/nodejs-mobile-cordova/ to fix the resolution of nodejs-mobile-gyp https://github.com/JaneaSystems/redmobile-nodejs-mobile-cordova/commit/6eb1ba5326418744b5eec4db16655804cae43acd

It uses a fork of https://github.com/mapbox/node-pre-gyp to fix using a NODEJS_MOBILE_GYP env var to resolve the node_gyp to use, since npm overwrites npm_config_node_gyp when passing it to modules. https://github.com/JaneaSystems/mapbox-node-pre-gyp/commit/cd5f1b4c0ca0b2b14a7d650441c3a9bff4150a6e
